### PR TITLE
Farm ID legitimacy check

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Target can be one of the following, to specify in which environment kernel boots
 - `dev`: devnet environment
 - `qa`: quality-assurance special dedicated network
 
-Theses network are configurable via the `config.py` file. The dictionnary pointed by `runmode` should contains
+These networks are configurable via the `config.py` file. The dictionary pointed by `runmode` should contain
 a short keyword and define a long pretty name.
 
 Any [argument] are optional, but are ordered and dependants (eg: you cannot provide extra argument without providing farmer-id network)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -9,25 +9,37 @@ import operator
 import sqlite3
 from subprocess import call
 from stat import *
-from flask import Flask, request, redirect, url_for, render_template, abort, Markup, make_response, send_from_directory
+from flask import (
+    Flask,
+    request,
+    redirect,
+    url_for,
+    render_template,
+    abort,
+    Markup,
+    make_response,
+    send_from_directory,
+)
 from werkzeug.utils import secure_filename
 from werkzeug.middleware.proxy_fix import ProxyFix
 from config import config
 
 #
-# Theses location should works out-of-box if you use default settings
+# These locations should works out-of-box if you use default settings
 #
 thispath = os.path.dirname(os.path.realpath(__file__))
 BASEPATH = os.path.join(thispath)
 
-app = Flask(__name__, static_url_path='/static')
+app = Flask(__name__, static_url_path="/static")
 app.url_map.strict_slashes = False
+
 
 #
 # Database
 #
 def db_open():
-    return sqlite3.connect(config['bootstrap-db'])
+    return sqlite3.connect(config["bootstrap-db"])
+
 
 def db_check():
     db = db_open()
@@ -42,25 +54,28 @@ def db_check():
         print("[-] database not initialized, please check installation steps")
         sys.exit(1)
 
+
 db_check()
+
 
 #
 # Helpers
 #
 def get_protocol():
-    if 'unsecure' in request.host:
-        return 'http'
+    if "unsecure" in request.host:
+        return "http"
 
-    return 'https'
+    return "https"
+
 
 # Full cycle ipxe script
 def ipxe_script(release, farmer, extra="", source=None):
     if not source:
-        source = 'net/%s.efi' % release
+        source = "net/%s.efi" % release
 
-    kernel = os.path.join(config['kernel-path'], source)
+    kernel = os.path.join(config["kernel-path"], source)
 
-    if release not in config['runmodes'].keys():
+    if release not in config["runmodes"].keys():
         abort(401)
 
     if not os.path.exists(kernel):
@@ -77,9 +92,8 @@ def ipxe_script(release, farmer, extra="", source=None):
     if extra:
         chain += " " + extra.replace("___", "/")
 
-
     settings = {
-        "release": config['runmodes'][release],
+        "release": config["runmodes"][release],
         "farmerid": farmer,
         "parameters": extra,
         "kernel": kernel_secure,
@@ -88,14 +102,15 @@ def ipxe_script(release, farmer, extra="", source=None):
 
     return render_template("boot.ipxe", **settings)
 
+
 # Debug cycle ipxe script
 def ipxe_debug_script(release, farmer, extra="", source=None):
     if not source:
-        source = 'net/%s.efi' % release
+        source = "net/%s.efi" % release
 
-    kernel = os.path.join(config['kernel-path'], source)
+    kernel = os.path.join(config["kernel-path"], source)
 
-    if release not in config['runmodes'].keys():
+    if release not in config["runmodes"].keys():
         abort(401)
 
     if not os.path.exists(kernel):
@@ -113,7 +128,7 @@ def ipxe_debug_script(release, farmer, extra="", source=None):
         chain += " " + extra.replace("___", "/")
 
     settings = {
-        "release": config['runmodes'][release],
+        "release": config["runmodes"][release],
         "farmerid": farmer,
         "parameters": extra,
         "kernel": kernel_secure,
@@ -127,10 +142,10 @@ def ipxe_debug_script(release, farmer, extra="", source=None):
 # Used for provision clients which have already network setup
 # by provision image
 def ipxe_quick_script(release, farmer, extra=""):
-    source = 'zero-os-development-zos-v2-generic.efi'
-    kernel = os.path.join(config['kernel-path'], source)
+    source = "zero-os-development-zos-v2-generic.efi"
+    kernel = os.path.join(config["kernel-path"], source)
 
-    if release not in config['runmodes'].keys():
+    if release not in config["runmodes"].keys():
         abort(401)
 
     if not os.path.exists(kernel):
@@ -146,13 +161,14 @@ def ipxe_quick_script(release, farmer, extra=""):
         cmdline += " " + extra
 
     settings = {
-        "release": config['runmodes'][release],
+        "release": config["runmodes"][release],
         "parameters": extra,
         "kernel": kernel,
         "cmdline": cmdline,
     }
 
     return render_template("boot-quick.ipxe", **settings)
+
 
 # Provisioning image requesting configuration on runtime
 def ipxe_provision():
@@ -170,18 +186,21 @@ def text_reply(payload):
 
     return response
 
+
 #
 # Routing
 #
-@app.route('/kernel/<path:filename>', methods=['GET'])
+@app.route("/kernel/<path:filename>", methods=["GET"])
 def download(filename):
     print("[+] downloading: %s" % filename)
-    return send_from_directory(directory=config['kernel-path'], filename=filename)
+    return send_from_directory(directory=config["kernel-path"], filename=filename)
 
-@app.route('/kernel/net/<path:filename>', methods=['GET'])
+
+@app.route("/kernel/net/<path:filename>", methods=["GET"])
 def download_net(filename):
     print("[+] downloading (network based): %s" % filename)
-    return send_from_directory(directory=config['kernel-net-path'], filename=filename)
+    return send_from_directory(directory=config["kernel-net-path"], filename=filename)
+
 
 #
 # Generic Image Generator
@@ -189,18 +208,22 @@ def download_net(filename):
 def srcdir_from_filename(targetfile):
     efi = ["ipxe.efi", "uefimg.img"]
     if targetfile in efi:
-       return config["ipxe-template-uefi"]
+        return config["ipxe-template-uefi"]
 
     return config["ipxe-template"]
+
 
 def download_mkresponse(data, filename):
     response = make_response(data)
     response.headers["Content-Type"] = "application/octet-stream"
-    response.headers['Content-Disposition'] = "inline; filename=%s" % filename
+    response.headers["Content-Disposition"] = "inline; filename=%s" % filename
 
     return response
 
-def generic_image_generator(release, farmer, extra, buildscript, targetfile, filename, kernel=None):
+
+def generic_image_generator(
+    release, farmer, extra, buildscript, targetfile, filename, kernel=None
+):
     response = make_response("Request failed")
     srcdir = srcdir_from_filename(targetfile)
 
@@ -211,7 +234,7 @@ def generic_image_generator(release, farmer, extra, buildscript, targetfile, fil
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
             f.write(ipxe_script(release, farmer, extra, kernel))
 
         print("[+] building: %s" % buildscript)
@@ -219,14 +242,17 @@ def generic_image_generator(release, farmer, extra, buildscript, targetfile, fil
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
+        with open(os.path.join(tmpdir, targetfile), "rb") as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
 
-def generic_debug_image_generator(release, farmer, extra, buildscript, targetfile, filename, kernel=None):
+
+def generic_debug_image_generator(
+    release, farmer, extra, buildscript, targetfile, filename, kernel=None
+):
     response = make_response("Request failed")
     srcdir = srcdir_from_filename(targetfile)
 
@@ -237,7 +263,7 @@ def generic_debug_image_generator(release, farmer, extra, buildscript, targetfil
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe debug script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
             f.write(ipxe_debug_script(release, farmer, extra, kernel))
 
         print("[+] building: %s" % buildscript)
@@ -245,12 +271,13 @@ def generic_debug_image_generator(release, farmer, extra, buildscript, targetfil
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
+        with open(os.path.join(tmpdir, targetfile), "rb") as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
+
 
 def generic_image_provision(buildscript, targetfile, filename):
     response = make_response("Request failed")
@@ -263,7 +290,7 @@ def generic_image_provision(buildscript, targetfile, filename):
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
             f.write(ipxe_provision())
 
         print("[+] building: %s" % buildscript)
@@ -271,12 +298,13 @@ def generic_image_provision(buildscript, targetfile, filename):
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
+        with open(os.path.join(tmpdir, targetfile), "rb") as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
+
 
 def generic_image_quickipxe(release, farmer, extra, buildscript, targetfile, filename):
     response = make_response("Request failed")
@@ -289,7 +317,7 @@ def generic_image_quickipxe(release, farmer, extra, buildscript, targetfile, fil
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
             f.write(ipxe_script(release, farmer, extra))
 
         print("[+] building: " % buildscript)
@@ -297,29 +325,33 @@ def generic_image_quickipxe(release, farmer, extra, buildscript, targetfile, fil
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
+        with open(os.path.join(tmpdir, targetfile), "rb") as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
 
+
 def baseurl():
     base = request.base_url[:-1]
-    base = base.replace("http://", "https://") # force https
+    base = base.replace("http://", "https://")  # force https
 
     return base
+
 
 def kernel_list():
     files = []
 
-    target = os.listdir(config['kernel-path'])
+    target = os.listdir(config["kernel-path"])
     ordered = {}
 
     for filename in target:
-        endpoint = os.path.join(config['kernel-path'], filename)
+        endpoint = os.path.join(config["kernel-path"], filename)
         stat = os.stat(endpoint, follow_symlinks=False)
-        updated = datetime.datetime.utcfromtimestamp(stat.st_mtime).strftime('%Y-%m-%d, %H:%M:%S (UTC)')
+        updated = datetime.datetime.utcfromtimestamp(stat.st_mtime).strftime(
+            "%Y-%m-%d, %H:%M:%S (UTC)"
+        )
 
         if not S_ISREG(stat.st_mode):
             continue
@@ -332,13 +364,17 @@ def kernel_list():
     for endpoint in starget:
         fullpath = endpoint[0]
         filename = os.path.basename(fullpath)
-        updated = datetime.datetime.utcfromtimestamp(endpoint[1]).strftime('%Y-%m-%d, %H:%M:%S (UTC)')
+        updated = datetime.datetime.utcfromtimestamp(endpoint[1]).strftime(
+            "%Y-%m-%d, %H:%M:%S (UTC)"
+        )
 
-        files.append({
-            'name': filename,
-            'release': filename[:-4],
-            'updated': updated,
-        })
+        files.append(
+            {
+                "name": filename,
+                "release": filename[:-4],
+                "updated": updated,
+            }
+        )
 
     return files
 
@@ -346,156 +382,219 @@ def kernel_list():
 #
 # Target Image Generator
 #
-@app.route('/iso/<release>', methods=['GET'])
+@app.route("/iso/<release>", methods=["GET"])
 def iso_release(release):
     return iso_release_farmer_extra(release, "", "")
 
-@app.route('/iso/<release>/<farmer>', methods=['GET'])
+
+@app.route("/iso/<release>/<farmer>", methods=["GET"])
 def iso_release_farmer(release, farmer):
     return iso_release_farmer_extra(release, farmer, "")
 
-@app.route('/iso/<release>/<farmer>/<extra>', methods=['GET'])
+
+@app.route("/iso/<release>/<farmer>/<extra>", methods=["GET"])
 def iso_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release)
+    return generic_image_generator(
+        release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release
+    )
 
-@app.route('/iso/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
+
+@app.route("/iso/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
 def iso_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
-    return generic_image_generator(release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release, kernel)
+    print(
+        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
+        % (release, farmer, extra, kernel)
+    )
+    return generic_image_generator(
+        release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release, kernel
+    )
 
 
-@app.route('/usb/<release>', methods=['GET'])
+@app.route("/usb/<release>", methods=["GET"])
 def usb_release(release):
     return usb_release_farmer_extra(release, "", "")
 
-@app.route('/usb/<release>/<farmer>', methods=['GET'])
+
+@app.route("/usb/<release>/<farmer>", methods=["GET"])
 def usb_release_farmer(release, farmer):
     return usb_release_farmer_extra(release, farmer, "")
 
-@app.route('/usb/<release>/<farmer>/<extra>', methods=['GET'])
+
+@app.route("/usb/<release>/<farmer>/<extra>", methods=["GET"])
 def usb_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release)
+    return generic_image_generator(
+        release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release
+    )
 
-@app.route('/usb/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
+
+@app.route("/usb/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
 def usb_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
-    return generic_image_generator(release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release, kernel)
+    print(
+        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
+        % (release, farmer, extra, kernel)
+    )
+    return generic_image_generator(
+        release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release, kernel
+    )
 
 
-
-@app.route('/krn-generic', methods=['GET'])
+@app.route("/krn-generic", methods=["GET"])
 def krn_generic():
     print("[+] generic ipxe kernel")
-    return generic_image_provision("mkkrn-generic.sh", "ipxe.lkrn", "ipxe-zero-os-generic.lkrn")
+    return generic_image_provision(
+        "mkkrn-generic.sh", "ipxe.lkrn", "ipxe-zero-os-generic.lkrn"
+    )
 
-@app.route('/uefi-generic', methods=['GET'])
+
+@app.route("/uefi-generic", methods=["GET"])
 def uefi_generic():
     print("[+] generic uefi ipxe")
-    return generic_image_provision("mkuefi-generic.sh", "ipxe.efi", "ipxe-zero-os-generic.efi")
+    return generic_image_provision(
+        "mkuefi-generic.sh", "ipxe.efi", "ipxe-zero-os-generic.efi"
+    )
 
 
-@app.route('/krn-provision', methods=['GET'])
+@app.route("/krn-provision", methods=["GET"])
 def krn_provision():
     print("[+] provision ipxe kernel")
-    return generic_image_quickipxe("mkkrn.sh", "ipxe.lkrn", "ipxe-zero-os-provision.lkrn")
+    return generic_image_quickipxe(
+        "mkkrn.sh", "ipxe.lkrn", "ipxe-zero-os-provision.lkrn"
+    )
 
-@app.route('/uefi-provision', methods=['GET'])
+
+@app.route("/uefi-provision", methods=["GET"])
 def uefi_provision():
     print("[+] provisioning uefi ipxe")
-    return generic_image_quickipxe("mkuefi.sh", "ipxe.efi", "ipxe-zero-os-provision.efi")
+    return generic_image_quickipxe(
+        "mkuefi.sh", "ipxe.efi", "ipxe-zero-os-provision.efi"
+    )
 
 
-@app.route('/krn/<release>', methods=['GET'])
+@app.route("/krn/<release>", methods=["GET"])
 def krn_release(release):
     return krn_release_farmer_extra(release, "", "")
 
-@app.route('/krn/<release>/<farmer>', methods=['GET'])
+
+@app.route("/krn/<release>/<farmer>", methods=["GET"])
 def krn_release_farmer(release, farmer):
     return krn_release_farmer_extra(release, farmer, "")
 
-@app.route('/krn/<release>/<farmer>/<extra>', methods=['GET'])
+
+@app.route("/krn/<release>/<farmer>/<extra>", methods=["GET"])
 def krn_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(release, farmer, extra, "mkkrn.sh", "ipxe.lkrn", "ipxe-%s.lkrn" % release)
+    return generic_image_generator(
+        release, farmer, extra, "mkkrn.sh", "ipxe.lkrn", "ipxe-%s.lkrn" % release
+    )
 
 
-@app.route('/uefi/<release>', methods=['GET'])
+@app.route("/uefi/<release>", methods=["GET"])
 def uefi_release(release):
     return uefi_release_farmer_extra(release, "", "")
 
-@app.route('/uefi/<release>/<farmer>', methods=['GET'])
+
+@app.route("/uefi/<release>/<farmer>", methods=["GET"])
 def uefi_release_farmer(release, farmer):
     return uefi_release_farmer_extra(release, farmer, "")
 
-@app.route('/uefi/<release>/<farmer>/<extra>', methods=['GET'])
+
+@app.route("/uefi/<release>/<farmer>/<extra>", methods=["GET"])
 def uefi_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release)
+    return generic_image_generator(
+        release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release
+    )
 
-@app.route('/uefi/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
+
+@app.route("/uefi/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
 def uefi_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
-    return generic_image_generator(release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release, kernel)
+    print(
+        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
+        % (release, farmer, extra, kernel)
+    )
+    return generic_image_generator(
+        release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release, kernel
+    )
 
 
-
-@app.route('/snponly/<release>/<farmer>/<extra>', methods=['GET'])
+@app.route("/snponly/<release>/<farmer>/<extra>", methods=["GET"])
 def snponly_release_farmer_extra(release, farmer, extra):
     print("[+] snponly, release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(release, farmer, extra, "mksnponly.sh", "ipxe.efi", "ipxe-snp-%s.efi" % release)
+    return generic_image_generator(
+        release, farmer, extra, "mksnponly.sh", "ipxe.efi", "ipxe-snp-%s.efi" % release
+    )
 
 
-
-
-@app.route('/uefimg/<release>', methods=['GET'])
+@app.route("/uefimg/<release>", methods=["GET"])
 def uefimg_release(release):
     return uefimg_release_farmer_extra(release, "", "")
 
-@app.route('/uefimg/<release>/<farmer>', methods=['GET'])
+
+@app.route("/uefimg/<release>/<farmer>", methods=["GET"])
 def uefimg_release_farmer(release, farmer):
     return uefimg_release_farmer_extra(release, farmer, "")
 
-@app.route('/uefimg/<release>/<farmer>/<extra>', methods=['GET'])
+
+@app.route("/uefimg/<release>/<farmer>/<extra>", methods=["GET"])
 def uefimg_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(release, farmer, extra, "mkuefimg.sh", "uefimg.img", "uefiusb-%s.img" % release)
+    return generic_image_generator(
+        release, farmer, extra, "mkuefimg.sh", "uefimg.img", "uefiusb-%s.img" % release
+    )
 
-@app.route('/uefimg/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
+
+@app.route("/uefimg/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
 def uefimg_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
-    return generic_image_generator(release, farmer, extra, "mkuefimg.sh", "uefimg.img", "uefiusb-%s.img" % release, kernel)
+    print(
+        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
+        % (release, farmer, extra, kernel)
+    )
+    return generic_image_generator(
+        release,
+        farmer,
+        extra,
+        "mkuefimg.sh",
+        "uefimg.img",
+        "uefiusb-%s.img" % release,
+        kernel,
+    )
 
 
-
-@app.route('/debug/<release>/<farmer>', methods=['GET'])
+@app.route("/debug/<release>/<farmer>", methods=["GET"])
 def uefimg_debug_release(release, farmer):
-    return generic_debug_image_generator(release, farmer, "", "mkuefimg.sh", "uefimg.img", "uefiusb-debug.img")
+    return generic_debug_image_generator(
+        release, farmer, "", "mkuefimg.sh", "uefimg.img", "uefiusb-debug.img"
+    )
 
 
-
-@app.route('/ipxe/<release>', methods=['GET'])
+@app.route("/ipxe/<release>", methods=["GET"])
 def ipxe_release(release):
     return ipxe_release_farmer_extra(release, "", "")
 
-@app.route('/ipxe/<release>/<farmer>', methods=['GET'])
+
+@app.route("/ipxe/<release>/<farmer>", methods=["GET"])
 def ipxe_release_farmer(release, farmer):
     return ipxe_release_farmer_extra(release, farmer, "")
 
-@app.route('/ipxe/<release>/<farmer>/<extra>', methods=['GET'])
+
+@app.route("/ipxe/<release>/<farmer>/<extra>", methods=["GET"])
 def ipxe_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
     return text_reply(ipxe_script(release, farmer, extra))
 
-@app.route('/ipxe/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
+
+@app.route("/ipxe/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
 def ipxe_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
+    print(
+        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
+        % (release, farmer, extra, kernel)
+    )
     return text_reply(ipxe_script(release, farmer, extra, kernel))
 
 
-
-@app.route('/provision/<client>')
+@app.route("/provision/<client>")
 def provision_client(client):
     print("[+] provisioning client: %s" % client)
 
@@ -503,7 +602,9 @@ def provision_client(client):
     t = (client,)
     c = db.cursor()
 
-    c.execute('SELECT client, release, zerotier, kargs FROM provision WHERE client = ?', t)
+    c.execute(
+        "SELECT client, release, zerotier, kargs FROM provision WHERE client = ?", t
+    )
     data = c.fetchone()
     db.close()
 
@@ -513,13 +614,14 @@ def provision_client(client):
 
     return text_reply(ipxe_quick_script(data[1], data[2], data[3]))
 
+
 #
 # Helpers
 #
 #
 # Web Frontend Routing
 #
-@app.route('/', methods=['GET'])
+@app.route("/", methods=["GET"])
 def homepage():
     content = {
         "baseurl": baseurl(),
@@ -527,15 +629,17 @@ def homepage():
 
     return render_template("generate.html", **content)
 
-@app.route('/images', methods=['GET'])
+
+@app.route("/images", methods=["GET"])
 def kernels():
     content = {
-        'files': kernel_list(),
+        "files": kernel_list(),
     }
 
     return render_template("kernels.html", **content)
 
-@app.route('/generate', methods=['GET'])
+
+@app.route("/generate", methods=["GET"])
 def generate():
     content = {
         "baseurl": baseurl(),
@@ -543,59 +647,59 @@ def generate():
 
     return render_template("generate.html", **content)
 
-
     return render_template("generate.html", **content)
 
-@app.route('/expert', methods=['GET'])
+
+@app.route("/expert", methods=["GET"])
 def expert():
-    content = {
-        "baseurl": baseurl(),
-        "kernels": kernel_list()
-    }
+    content = {"baseurl": baseurl(), "kernels": kernel_list()}
 
     return render_template("expert.html", **content)
 
-@app.route('/api/kernel', methods=['POST'])
+
+@app.route("/api/kernel", methods=["POST"])
 def api_kernel():
     if not request.cookies.get("token"):
-        return {'status': 'error', 'message': 'token not found'}
+        return {"status": "error", "message": "token not found"}
 
-    if request.cookies.get("token") != config['api-token']:
-        return {'status': 'error', 'message': 'invalid token'}
+    if request.cookies.get("token") != config["api-token"]:
+        return {"status": "error", "message": "invalid token"}
 
-    if 'kernel' not in request.files:
-        return {'status': 'error', 'message': 'no file found'}
+    if "kernel" not in request.files:
+        return {"status": "error", "message": "no file found"}
 
-    file = request.files['kernel']
+    file = request.files["kernel"]
 
-    if file.filename == '':
-        return {'status': 'error', 'message': 'no file selected'}
+    if file.filename == "":
+        return {"status": "error", "message": "no file selected"}
 
-    source = os.path.join(config['kernel-path'], file.filename)
+    source = os.path.join(config["kernel-path"], file.filename)
     print(source)
 
     file.save(source)
 
-    return {'status': 'success'}
+    return {"status": "success"}
 
-@app.route('/api/symlink/<linkname>/<target>')
+
+@app.route("/api/symlink/<linkname>/<target>")
 def api_symlink(linkname, target):
     if not request.cookies.get("token"):
-        return {'status': 'error', 'message': 'token not found'}
+        return {"status": "error", "message": "token not found"}
 
-    if request.cookies.get("token") != config['api-token']:
-        return {'status': 'error', 'message': 'invalid token'}
+    if request.cookies.get("token") != config["api-token"]:
+        return {"status": "error", "message": "invalid token"}
 
-    check = os.path.join(config['kernel-path'], linkname)
+    check = os.path.join(config["kernel-path"], linkname)
     if os.path.islink(check) or os.path.isfile(check):
         os.remove(check)
 
     now = os.getcwd()
-    os.chdir(config['kernel-path'])
+    os.chdir(config["kernel-path"])
     os.symlink(target, linkname)
     os.chdir(now)
 
-    return {'status': 'success'}
+    return {"status": "success"}
+
 
 print("[+] listening")
-app.run(host="0.0.0.0", port=config['http-port'], debug=config['debug'], threaded=True)
+app.run(host="0.0.0.0", port=config["http-port"], debug=config["debug"], threaded=True)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -9,37 +9,25 @@ import operator
 import sqlite3
 from subprocess import call
 from stat import *
-from flask import (
-    Flask,
-    request,
-    redirect,
-    url_for,
-    render_template,
-    abort,
-    Markup,
-    make_response,
-    send_from_directory,
-)
+from flask import Flask, request, redirect, url_for, render_template, abort, Markup, make_response, send_from_directory
 from werkzeug.utils import secure_filename
 from werkzeug.middleware.proxy_fix import ProxyFix
 from config import config
 
 #
-# These locations should works out-of-box if you use default settings
+# Theses location should works out-of-box if you use default settings
 #
 thispath = os.path.dirname(os.path.realpath(__file__))
 BASEPATH = os.path.join(thispath)
 
-app = Flask(__name__, static_url_path="/static")
+app = Flask(__name__, static_url_path='/static')
 app.url_map.strict_slashes = False
-
 
 #
 # Database
 #
 def db_open():
-    return sqlite3.connect(config["bootstrap-db"])
-
+    return sqlite3.connect(config['bootstrap-db'])
 
 def db_check():
     db = db_open()
@@ -54,28 +42,25 @@ def db_check():
         print("[-] database not initialized, please check installation steps")
         sys.exit(1)
 
-
 db_check()
-
 
 #
 # Helpers
 #
 def get_protocol():
-    if "unsecure" in request.host:
-        return "http"
+    if 'unsecure' in request.host:
+        return 'http'
 
-    return "https"
-
+    return 'https'
 
 # Full cycle ipxe script
 def ipxe_script(release, farmer, extra="", source=None):
     if not source:
-        source = "net/%s.efi" % release
+        source = 'net/%s.efi' % release
 
-    kernel = os.path.join(config["kernel-path"], source)
+    kernel = os.path.join(config['kernel-path'], source)
 
-    if release not in config["runmodes"].keys():
+    if release not in config['runmodes'].keys():
         abort(401)
 
     if not os.path.exists(kernel):
@@ -92,8 +77,9 @@ def ipxe_script(release, farmer, extra="", source=None):
     if extra:
         chain += " " + extra.replace("___", "/")
 
+
     settings = {
-        "release": config["runmodes"][release],
+        "release": config['runmodes'][release],
         "farmerid": farmer,
         "parameters": extra,
         "kernel": kernel_secure,
@@ -102,15 +88,14 @@ def ipxe_script(release, farmer, extra="", source=None):
 
     return render_template("boot.ipxe", **settings)
 
-
 # Debug cycle ipxe script
 def ipxe_debug_script(release, farmer, extra="", source=None):
     if not source:
-        source = "net/%s.efi" % release
+        source = 'net/%s.efi' % release
 
-    kernel = os.path.join(config["kernel-path"], source)
+    kernel = os.path.join(config['kernel-path'], source)
 
-    if release not in config["runmodes"].keys():
+    if release not in config['runmodes'].keys():
         abort(401)
 
     if not os.path.exists(kernel):
@@ -128,7 +113,7 @@ def ipxe_debug_script(release, farmer, extra="", source=None):
         chain += " " + extra.replace("___", "/")
 
     settings = {
-        "release": config["runmodes"][release],
+        "release": config['runmodes'][release],
         "farmerid": farmer,
         "parameters": extra,
         "kernel": kernel_secure,
@@ -142,10 +127,10 @@ def ipxe_debug_script(release, farmer, extra="", source=None):
 # Used for provision clients which have already network setup
 # by provision image
 def ipxe_quick_script(release, farmer, extra=""):
-    source = "zero-os-development-zos-v2-generic.efi"
-    kernel = os.path.join(config["kernel-path"], source)
+    source = 'zero-os-development-zos-v2-generic.efi'
+    kernel = os.path.join(config['kernel-path'], source)
 
-    if release not in config["runmodes"].keys():
+    if release not in config['runmodes'].keys():
         abort(401)
 
     if not os.path.exists(kernel):
@@ -161,14 +146,13 @@ def ipxe_quick_script(release, farmer, extra=""):
         cmdline += " " + extra
 
     settings = {
-        "release": config["runmodes"][release],
+        "release": config['runmodes'][release],
         "parameters": extra,
         "kernel": kernel,
         "cmdline": cmdline,
     }
 
     return render_template("boot-quick.ipxe", **settings)
-
 
 # Provisioning image requesting configuration on runtime
 def ipxe_provision():
@@ -186,21 +170,18 @@ def text_reply(payload):
 
     return response
 
-
 #
 # Routing
 #
-@app.route("/kernel/<path:filename>", methods=["GET"])
+@app.route('/kernel/<path:filename>', methods=['GET'])
 def download(filename):
     print("[+] downloading: %s" % filename)
-    return send_from_directory(directory=config["kernel-path"], filename=filename)
+    return send_from_directory(directory=config['kernel-path'], filename=filename)
 
-
-@app.route("/kernel/net/<path:filename>", methods=["GET"])
+@app.route('/kernel/net/<path:filename>', methods=['GET'])
 def download_net(filename):
     print("[+] downloading (network based): %s" % filename)
-    return send_from_directory(directory=config["kernel-net-path"], filename=filename)
-
+    return send_from_directory(directory=config['kernel-net-path'], filename=filename)
 
 #
 # Generic Image Generator
@@ -208,22 +189,18 @@ def download_net(filename):
 def srcdir_from_filename(targetfile):
     efi = ["ipxe.efi", "uefimg.img"]
     if targetfile in efi:
-        return config["ipxe-template-uefi"]
+       return config["ipxe-template-uefi"]
 
     return config["ipxe-template"]
-
 
 def download_mkresponse(data, filename):
     response = make_response(data)
     response.headers["Content-Type"] = "application/octet-stream"
-    response.headers["Content-Disposition"] = "inline; filename=%s" % filename
+    response.headers['Content-Disposition'] = "inline; filename=%s" % filename
 
     return response
 
-
-def generic_image_generator(
-    release, farmer, extra, buildscript, targetfile, filename, kernel=None
-):
+def generic_image_generator(release, farmer, extra, buildscript, targetfile, filename, kernel=None):
     response = make_response("Request failed")
     srcdir = srcdir_from_filename(targetfile)
 
@@ -234,7 +211,7 @@ def generic_image_generator(
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
             f.write(ipxe_script(release, farmer, extra, kernel))
 
         print("[+] building: %s" % buildscript)
@@ -242,17 +219,14 @@ def generic_image_generator(
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), "rb") as f:
+        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
 
-
-def generic_debug_image_generator(
-    release, farmer, extra, buildscript, targetfile, filename, kernel=None
-):
+def generic_debug_image_generator(release, farmer, extra, buildscript, targetfile, filename, kernel=None):
     response = make_response("Request failed")
     srcdir = srcdir_from_filename(targetfile)
 
@@ -263,7 +237,7 @@ def generic_debug_image_generator(
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe debug script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
             f.write(ipxe_debug_script(release, farmer, extra, kernel))
 
         print("[+] building: %s" % buildscript)
@@ -271,13 +245,12 @@ def generic_debug_image_generator(
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), "rb") as f:
+        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
-
 
 def generic_image_provision(buildscript, targetfile, filename):
     response = make_response("Request failed")
@@ -290,7 +263,7 @@ def generic_image_provision(buildscript, targetfile, filename):
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
             f.write(ipxe_provision())
 
         print("[+] building: %s" % buildscript)
@@ -298,13 +271,12 @@ def generic_image_provision(buildscript, targetfile, filename):
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), "rb") as f:
+        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
-
 
 def generic_image_quickipxe(release, farmer, extra, buildscript, targetfile, filename):
     response = make_response("Request failed")
@@ -317,7 +289,7 @@ def generic_image_quickipxe(release, farmer, extra, buildscript, targetfile, fil
         call(["cp", "-ar", srcdir, src])
 
         print("[+] creating ipxe script")
-        with open(os.path.join(tmpdir, "boot.ipxe"), "w") as f:
+        with open(os.path.join(tmpdir, "boot.ipxe"), 'w') as f:
             f.write(ipxe_script(release, farmer, extra))
 
         print("[+] building: " % buildscript)
@@ -325,33 +297,29 @@ def generic_image_quickipxe(release, farmer, extra, buildscript, targetfile, fil
         call(["bash", script, tmpdir])
 
         filecontents = ""
-        with open(os.path.join(tmpdir, targetfile), "rb") as f:
+        with open(os.path.join(tmpdir, targetfile), 'rb') as f:
             filecontents = f.read()
 
         response = download_mkresponse(filecontents, filename)
 
     return response
 
-
 def baseurl():
     base = request.base_url[:-1]
-    base = base.replace("http://", "https://")  # force https
+    base = base.replace("http://", "https://") # force https
 
     return base
-
 
 def kernel_list():
     files = []
 
-    target = os.listdir(config["kernel-path"])
+    target = os.listdir(config['kernel-path'])
     ordered = {}
 
     for filename in target:
-        endpoint = os.path.join(config["kernel-path"], filename)
+        endpoint = os.path.join(config['kernel-path'], filename)
         stat = os.stat(endpoint, follow_symlinks=False)
-        updated = datetime.datetime.utcfromtimestamp(stat.st_mtime).strftime(
-            "%Y-%m-%d, %H:%M:%S (UTC)"
-        )
+        updated = datetime.datetime.utcfromtimestamp(stat.st_mtime).strftime('%Y-%m-%d, %H:%M:%S (UTC)')
 
         if not S_ISREG(stat.st_mode):
             continue
@@ -364,17 +332,13 @@ def kernel_list():
     for endpoint in starget:
         fullpath = endpoint[0]
         filename = os.path.basename(fullpath)
-        updated = datetime.datetime.utcfromtimestamp(endpoint[1]).strftime(
-            "%Y-%m-%d, %H:%M:%S (UTC)"
-        )
+        updated = datetime.datetime.utcfromtimestamp(endpoint[1]).strftime('%Y-%m-%d, %H:%M:%S (UTC)')
 
-        files.append(
-            {
-                "name": filename,
-                "release": filename[:-4],
-                "updated": updated,
-            }
-        )
+        files.append({
+            'name': filename,
+            'release': filename[:-4],
+            'updated': updated,
+        })
 
     return files
 
@@ -382,219 +346,156 @@ def kernel_list():
 #
 # Target Image Generator
 #
-@app.route("/iso/<release>", methods=["GET"])
+@app.route('/iso/<release>', methods=['GET'])
 def iso_release(release):
     return iso_release_farmer_extra(release, "", "")
 
-
-@app.route("/iso/<release>/<farmer>", methods=["GET"])
+@app.route('/iso/<release>/<farmer>', methods=['GET'])
 def iso_release_farmer(release, farmer):
     return iso_release_farmer_extra(release, farmer, "")
 
-
-@app.route("/iso/<release>/<farmer>/<extra>", methods=["GET"])
+@app.route('/iso/<release>/<farmer>/<extra>', methods=['GET'])
 def iso_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(
-        release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release
-    )
+    return generic_image_generator(release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release)
 
-
-@app.route("/iso/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
+@app.route('/iso/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
 def iso_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print(
-        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
-        % (release, farmer, extra, kernel)
-    )
-    return generic_image_generator(
-        release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release, kernel
-    )
+    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
+    return generic_image_generator(release, farmer, extra, "mkiso.sh", "ipxe.iso", "ipxe-%s.iso" % release, kernel)
 
 
-@app.route("/usb/<release>", methods=["GET"])
+@app.route('/usb/<release>', methods=['GET'])
 def usb_release(release):
     return usb_release_farmer_extra(release, "", "")
 
-
-@app.route("/usb/<release>/<farmer>", methods=["GET"])
+@app.route('/usb/<release>/<farmer>', methods=['GET'])
 def usb_release_farmer(release, farmer):
     return usb_release_farmer_extra(release, farmer, "")
 
-
-@app.route("/usb/<release>/<farmer>/<extra>", methods=["GET"])
+@app.route('/usb/<release>/<farmer>/<extra>', methods=['GET'])
 def usb_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(
-        release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release
-    )
+    return generic_image_generator(release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release)
 
-
-@app.route("/usb/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
+@app.route('/usb/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
 def usb_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print(
-        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
-        % (release, farmer, extra, kernel)
-    )
-    return generic_image_generator(
-        release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release, kernel
-    )
+    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
+    return generic_image_generator(release, farmer, extra, "mkusb.sh", "ipxe.usb", "ipxe-%s.img" % release, kernel)
 
 
-@app.route("/krn-generic", methods=["GET"])
+
+@app.route('/krn-generic', methods=['GET'])
 def krn_generic():
     print("[+] generic ipxe kernel")
-    return generic_image_provision(
-        "mkkrn-generic.sh", "ipxe.lkrn", "ipxe-zero-os-generic.lkrn"
-    )
+    return generic_image_provision("mkkrn-generic.sh", "ipxe.lkrn", "ipxe-zero-os-generic.lkrn")
 
-
-@app.route("/uefi-generic", methods=["GET"])
+@app.route('/uefi-generic', methods=['GET'])
 def uefi_generic():
     print("[+] generic uefi ipxe")
-    return generic_image_provision(
-        "mkuefi-generic.sh", "ipxe.efi", "ipxe-zero-os-generic.efi"
-    )
+    return generic_image_provision("mkuefi-generic.sh", "ipxe.efi", "ipxe-zero-os-generic.efi")
 
 
-@app.route("/krn-provision", methods=["GET"])
+@app.route('/krn-provision', methods=['GET'])
 def krn_provision():
     print("[+] provision ipxe kernel")
-    return generic_image_quickipxe(
-        "mkkrn.sh", "ipxe.lkrn", "ipxe-zero-os-provision.lkrn"
-    )
+    return generic_image_quickipxe("mkkrn.sh", "ipxe.lkrn", "ipxe-zero-os-provision.lkrn")
 
-
-@app.route("/uefi-provision", methods=["GET"])
+@app.route('/uefi-provision', methods=['GET'])
 def uefi_provision():
     print("[+] provisioning uefi ipxe")
-    return generic_image_quickipxe(
-        "mkuefi.sh", "ipxe.efi", "ipxe-zero-os-provision.efi"
-    )
+    return generic_image_quickipxe("mkuefi.sh", "ipxe.efi", "ipxe-zero-os-provision.efi")
 
 
-@app.route("/krn/<release>", methods=["GET"])
+@app.route('/krn/<release>', methods=['GET'])
 def krn_release(release):
     return krn_release_farmer_extra(release, "", "")
 
-
-@app.route("/krn/<release>/<farmer>", methods=["GET"])
+@app.route('/krn/<release>/<farmer>', methods=['GET'])
 def krn_release_farmer(release, farmer):
     return krn_release_farmer_extra(release, farmer, "")
 
-
-@app.route("/krn/<release>/<farmer>/<extra>", methods=["GET"])
+@app.route('/krn/<release>/<farmer>/<extra>', methods=['GET'])
 def krn_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(
-        release, farmer, extra, "mkkrn.sh", "ipxe.lkrn", "ipxe-%s.lkrn" % release
-    )
+    return generic_image_generator(release, farmer, extra, "mkkrn.sh", "ipxe.lkrn", "ipxe-%s.lkrn" % release)
 
 
-@app.route("/uefi/<release>", methods=["GET"])
+@app.route('/uefi/<release>', methods=['GET'])
 def uefi_release(release):
     return uefi_release_farmer_extra(release, "", "")
 
-
-@app.route("/uefi/<release>/<farmer>", methods=["GET"])
+@app.route('/uefi/<release>/<farmer>', methods=['GET'])
 def uefi_release_farmer(release, farmer):
     return uefi_release_farmer_extra(release, farmer, "")
 
-
-@app.route("/uefi/<release>/<farmer>/<extra>", methods=["GET"])
+@app.route('/uefi/<release>/<farmer>/<extra>', methods=['GET'])
 def uefi_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(
-        release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release
-    )
+    return generic_image_generator(release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release)
 
-
-@app.route("/uefi/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
+@app.route('/uefi/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
 def uefi_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print(
-        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
-        % (release, farmer, extra, kernel)
-    )
-    return generic_image_generator(
-        release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release, kernel
-    )
+    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
+    return generic_image_generator(release, farmer, extra, "mkuefi.sh", "ipxe.efi", "ipxe-%s.efi" % release, kernel)
 
 
-@app.route("/snponly/<release>/<farmer>/<extra>", methods=["GET"])
+
+@app.route('/snponly/<release>/<farmer>/<extra>', methods=['GET'])
 def snponly_release_farmer_extra(release, farmer, extra):
     print("[+] snponly, release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(
-        release, farmer, extra, "mksnponly.sh", "ipxe.efi", "ipxe-snp-%s.efi" % release
-    )
+    return generic_image_generator(release, farmer, extra, "mksnponly.sh", "ipxe.efi", "ipxe-snp-%s.efi" % release)
 
 
-@app.route("/uefimg/<release>", methods=["GET"])
+
+
+@app.route('/uefimg/<release>', methods=['GET'])
 def uefimg_release(release):
     return uefimg_release_farmer_extra(release, "", "")
 
-
-@app.route("/uefimg/<release>/<farmer>", methods=["GET"])
+@app.route('/uefimg/<release>/<farmer>', methods=['GET'])
 def uefimg_release_farmer(release, farmer):
     return uefimg_release_farmer_extra(release, farmer, "")
 
-
-@app.route("/uefimg/<release>/<farmer>/<extra>", methods=["GET"])
+@app.route('/uefimg/<release>/<farmer>/<extra>', methods=['GET'])
 def uefimg_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
-    return generic_image_generator(
-        release, farmer, extra, "mkuefimg.sh", "uefimg.img", "uefiusb-%s.img" % release
-    )
+    return generic_image_generator(release, farmer, extra, "mkuefimg.sh", "uefimg.img", "uefiusb-%s.img" % release)
 
-
-@app.route("/uefimg/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
+@app.route('/uefimg/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
 def uefimg_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print(
-        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
-        % (release, farmer, extra, kernel)
-    )
-    return generic_image_generator(
-        release,
-        farmer,
-        extra,
-        "mkuefimg.sh",
-        "uefimg.img",
-        "uefiusb-%s.img" % release,
-        kernel,
-    )
+    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
+    return generic_image_generator(release, farmer, extra, "mkuefimg.sh", "uefimg.img", "uefiusb-%s.img" % release, kernel)
 
 
-@app.route("/debug/<release>/<farmer>", methods=["GET"])
+
+@app.route('/debug/<release>/<farmer>', methods=['GET'])
 def uefimg_debug_release(release, farmer):
-    return generic_debug_image_generator(
-        release, farmer, "", "mkuefimg.sh", "uefimg.img", "uefiusb-debug.img"
-    )
+    return generic_debug_image_generator(release, farmer, "", "mkuefimg.sh", "uefimg.img", "uefiusb-debug.img")
 
 
-@app.route("/ipxe/<release>", methods=["GET"])
+
+@app.route('/ipxe/<release>', methods=['GET'])
 def ipxe_release(release):
     return ipxe_release_farmer_extra(release, "", "")
 
-
-@app.route("/ipxe/<release>/<farmer>", methods=["GET"])
+@app.route('/ipxe/<release>/<farmer>', methods=['GET'])
 def ipxe_release_farmer(release, farmer):
     return ipxe_release_farmer_extra(release, farmer, "")
 
-
-@app.route("/ipxe/<release>/<farmer>/<extra>", methods=["GET"])
+@app.route('/ipxe/<release>/<farmer>/<extra>', methods=['GET'])
 def ipxe_release_farmer_extra(release, farmer, extra):
     print("[+] release: %s, network: %s, extra: %s" % (release, farmer, extra))
     return text_reply(ipxe_script(release, farmer, extra))
 
-
-@app.route("/ipxe/<release>/<farmer>/<extra>/<kernel>", methods=["GET"])
+@app.route('/ipxe/<release>/<farmer>/<extra>/<kernel>', methods=['GET'])
 def ipxe_release_farmer_extra_kernel(release, farmer, extra, kernel):
-    print(
-        "[+] release: %s, network: %s, extra: %s [kernel: %s]"
-        % (release, farmer, extra, kernel)
-    )
+    print("[+] release: %s, network: %s, extra: %s [kernel: %s]" % (release, farmer, extra, kernel))
     return text_reply(ipxe_script(release, farmer, extra, kernel))
 
 
-@app.route("/provision/<client>")
+
+@app.route('/provision/<client>')
 def provision_client(client):
     print("[+] provisioning client: %s" % client)
 
@@ -602,9 +503,7 @@ def provision_client(client):
     t = (client,)
     c = db.cursor()
 
-    c.execute(
-        "SELECT client, release, zerotier, kargs FROM provision WHERE client = ?", t
-    )
+    c.execute('SELECT client, release, zerotier, kargs FROM provision WHERE client = ?', t)
     data = c.fetchone()
     db.close()
 
@@ -614,14 +513,13 @@ def provision_client(client):
 
     return text_reply(ipxe_quick_script(data[1], data[2], data[3]))
 
-
 #
 # Helpers
 #
 #
 # Web Frontend Routing
 #
-@app.route("/", methods=["GET"])
+@app.route('/', methods=['GET'])
 def homepage():
     content = {
         "baseurl": baseurl(),
@@ -629,17 +527,15 @@ def homepage():
 
     return render_template("generate.html", **content)
 
-
-@app.route("/images", methods=["GET"])
+@app.route('/images', methods=['GET'])
 def kernels():
     content = {
-        "files": kernel_list(),
+        'files': kernel_list(),
     }
 
     return render_template("kernels.html", **content)
 
-
-@app.route("/generate", methods=["GET"])
+@app.route('/generate', methods=['GET'])
 def generate():
     content = {
         "baseurl": baseurl(),
@@ -647,59 +543,59 @@ def generate():
 
     return render_template("generate.html", **content)
 
+
     return render_template("generate.html", **content)
 
-
-@app.route("/expert", methods=["GET"])
+@app.route('/expert', methods=['GET'])
 def expert():
-    content = {"baseurl": baseurl(), "kernels": kernel_list()}
+    content = {
+        "baseurl": baseurl(),
+        "kernels": kernel_list()
+    }
 
     return render_template("expert.html", **content)
 
-
-@app.route("/api/kernel", methods=["POST"])
+@app.route('/api/kernel', methods=['POST'])
 def api_kernel():
     if not request.cookies.get("token"):
-        return {"status": "error", "message": "token not found"}
+        return {'status': 'error', 'message': 'token not found'}
 
-    if request.cookies.get("token") != config["api-token"]:
-        return {"status": "error", "message": "invalid token"}
+    if request.cookies.get("token") != config['api-token']:
+        return {'status': 'error', 'message': 'invalid token'}
 
-    if "kernel" not in request.files:
-        return {"status": "error", "message": "no file found"}
+    if 'kernel' not in request.files:
+        return {'status': 'error', 'message': 'no file found'}
 
-    file = request.files["kernel"]
+    file = request.files['kernel']
 
-    if file.filename == "":
-        return {"status": "error", "message": "no file selected"}
+    if file.filename == '':
+        return {'status': 'error', 'message': 'no file selected'}
 
-    source = os.path.join(config["kernel-path"], file.filename)
+    source = os.path.join(config['kernel-path'], file.filename)
     print(source)
 
     file.save(source)
 
-    return {"status": "success"}
+    return {'status': 'success'}
 
-
-@app.route("/api/symlink/<linkname>/<target>")
+@app.route('/api/symlink/<linkname>/<target>')
 def api_symlink(linkname, target):
     if not request.cookies.get("token"):
-        return {"status": "error", "message": "token not found"}
+        return {'status': 'error', 'message': 'token not found'}
 
-    if request.cookies.get("token") != config["api-token"]:
-        return {"status": "error", "message": "invalid token"}
+    if request.cookies.get("token") != config['api-token']:
+        return {'status': 'error', 'message': 'invalid token'}
 
-    check = os.path.join(config["kernel-path"], linkname)
+    check = os.path.join(config['kernel-path'], linkname)
     if os.path.islink(check) or os.path.isfile(check):
         os.remove(check)
 
     now = os.getcwd()
-    os.chdir(config["kernel-path"])
+    os.chdir(config['kernel-path'])
     os.symlink(target, linkname)
     os.chdir(now)
 
-    return {"status": "success"}
-
+    return {'status': 'success'}
 
 print("[+] listening")
-app.run(host="0.0.0.0", port=config["http-port"], debug=config["debug"], threaded=True)
+app.run(host="0.0.0.0", port=config['http-port'], debug=config['debug'], threaded=True)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -15,7 +15,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from config import config
 
 #
-# Theses location should works out-of-box if you use default settings
+# These locations should works out-of-box if you use default settings
 #
 thispath = os.path.dirname(os.path.realpath(__file__))
 BASEPATH = os.path.join(thispath)

--- a/static/js/generate.js
+++ b/static/js/generate.js
@@ -25,19 +25,17 @@ function farmerid_valid() {
 }
 
 function update_trigger(initialAllValid) {
+    const regex = /^\d+$/;
     var fid = $("#farmerid").val();
 
-    // farmer id needs to be a positive non null integer with no coma or dot
-    // check related to issue #4
-    fid = fid.split('.').join("").split(',').join("");
-
-    if(/\D/.test(fid)) {
-        $('#farmerid-cleared').html("Invalid");
+    if(fid === "") {
+        $('#farmerid-cleared').html("Missing");
         return farmerid_invalid();
     }
 
-    if(fid == "") {
-        $('#farmerid-cleared').html("Missing");
+    // the fid (farmer id) may only contain integers 0-9
+    if(! regex.test(fid)) {
+        $('#farmerid-cleared').html("Invalid");
         return farmerid_invalid();
     }
 
@@ -45,10 +43,7 @@ function update_trigger(initialAllValid) {
 
     $('#farmerid-cleared').html(fid);
 
-    if(Number.isInteger(fid) && fid > 0)
-        return farmerid_valid();
-
-    return farmerid_invalid();
+    return farmerid_valid();
 }
 
 function update_url() {


### PR DESCRIPTION
> :warning: **Needs extra testing**: someone other than me should test this as well.


## Issue
In the current implementation, the farm ID textfield does not check the given ID. This makes it easy to enter the wrong one without knowing any better. This is bad practice in general, and can cause cryptic issues down the line with ZOS. I have personally used a wrong farm ID by accident and  thus had issues with my node, and the cause was not instantly clear.

This is an extra step in ensuring no node is created with a wacky farm ID

![image](https://github.com/threefoldtech/0-bootstrap/assets/73200952/298ffaf6-4a14-4c73-b3e1-10b47866146c)

## Fix

To combat this issue, I've implemented a simple fetch from the Threefold GraphQL database to verify a farm exists with the given ID. 

As a QOL change I made the right label show the name for the farm, as an extra measure to ensure correct ID.
To fix the issue of retrieving the ID from that field, I introduced a variable that holds the ID, and the URL gets generated from that.

https://github.com/threefoldtech/0-bootstrap/assets/73200952/3cb91076-6ac9-4365-abc8-104f2a4178f1

(*reload page if giving error*)




### Sanitizing input
[issue #4 ](https://github.com/threefoldtech/0-bootstrap/issues/4) was not implemented fully, making it possible to still input dots (even though these are removed before use). This is now also taken care of.

- fixed minor spelling mistakes